### PR TITLE
Update userChrome.css

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -150,10 +150,13 @@ toolbarseparator {
 /* The first one also changes the text's color for some reason */
 .tab-content[selected="true"]
 {
-
-	background-color: #1a1a1a !important;
 	font-weight: bold !important;
 	color: #b24747 !important;
+}
+
+/*background-color of selected tab*/
+.tab-background[multiselected="true"], .tab-background[selected="true"]{
+  	background: #1a1a1a !important;
 }
 
 #tabbrowser-tabs {


### PR DESCRIPTION
smal bugfix.  if you open a site in a new multi-account container and the tab is selectet, the color marker-line ist not vissible. Now it works fine.